### PR TITLE
Allow text/xml for content-type

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,4 +65,4 @@ module.exports = function (opts) {
 
 };
 
-exports.regexp = /^application\/([\w!#\$%&\*`\-\.\^~]*\+)?xml$/i;
+exports.regexp = /^(text\/xml|application\/([\w!#\$%&\*`\-\.\^~]+\+)?xml)$/i;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-xml-bodyparser",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Simple XML body parser connect/express middleware",
   "author": "Matthias Adler <macedigital@gmail.com> (http://matthiasadler.info/)",
   "homepage": "https://github.com/macedigital/express-xml-bodyparser.git",


### PR DESCRIPTION
Valid content types for xml should include `text/xml`, see [RFC 2376](http://www.ietf.org/rfc/rfc2376.txt). 

As you can see I got one of those _rare cases_ at hand. :)
