### PR TITLE
Expose regexp used to test upon mime

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,4 +65,4 @@ module.exports = function (opts) {
 
 };
 
-exports.regexp = /^(text\/xml|application\/([\w!#\$%&\*`\-\.\^~]+\+)?xml)$/i;
+module.exports.regexp = /^(text\/xml|application\/([\w!#\$%&\*`\-\.\^~]+\+)?xml)$/i;


### PR DESCRIPTION
Exports was reassigned, so line 68 regexp was not exported.
Not really sure if it was intended to be hidden, but I can not access regexp via require.

I made this change so it will.
