### PR TITLE
Fix invalid char before root tag

### DIFF
--- a/lib/types/xml.js
+++ b/lib/types/xml.js
@@ -25,7 +25,7 @@ module.exports.regexp = regexp;
 function xmlparser(options) {
 
   var parserOptions = util._extend({
-      async: true,
+      async: false,
       explicitArray: true,
       normalize: true,
       normalizeTags: true,
@@ -82,7 +82,7 @@ function xmlparser(options) {
     });
 
     // since xml2js v0.4.5 parse errors propagate without being able to catch them otherwise
-    parser.saxParser.onerror = responseHandler;
+    // parser.saxParser.onerror = responseHandler;
 
     // in case `parseString` callback never was called, ensure response is sent
     parser.saxParser.onend = function() {
@@ -92,7 +92,7 @@ function xmlparser(options) {
     };
 
     req.on('end', function () {
-      
+
       // invalid xml, length required
       if (data.trim().length === 0) {
         return next(error(411));

--- a/lib/types/xml.js
+++ b/lib/types/xml.js
@@ -81,9 +81,6 @@ function xmlparser(options) {
       data += chunk;
     });
 
-    // since xml2js v0.4.5 parse errors propagate without being able to catch them otherwise
-    // parser.saxParser.onerror = responseHandler;
-
     // in case `parseString` callback never was called, ensure response is sent
     parser.saxParser.onend = function() {
       if (req.complete && req.rawBody === undefined) {

--- a/test/test.js
+++ b/test/test.js
@@ -104,6 +104,14 @@ describe('XmlParserMiddleware', function () {
         .expect(400, done);
     });
 
+    it('should throw 400 on invalid char before root tag', function (done) {
+      request(app)
+        .post('/')
+        .set('Content-Type', 'application/vendor-spec+xml')
+        .send('"<xml>ok</xml>')
+        .expect(400, done);
+    });
+
     it('should throw 400 on unexpected end', function (done) {
       request(app)
         .post('/')
@@ -118,7 +126,9 @@ describe('XmlParserMiddleware', function () {
         .set('Content-Type', 'application/xml')
         .send('<xml></xml>')
         .expect(200, function (err, res) {
-          assert.deepEqual(res.body, {});
+          assert.deepEqual(res.body, {
+            xml: ''
+          });
           done();
         });
     });
@@ -144,7 +154,7 @@ describe('XmlParserMiddleware', function () {
         .send('<xml>this is invalid')
         .expect(400, done);
     });
-    
+
     it('should throw 400 on invalid xml body', function (done) {
       request(app)
         .post('/')
@@ -237,7 +247,7 @@ describe('XmlParserMiddleware', function () {
     app.post('/', function (req, res) {
       res.json(req.body);
     });
-    
+
     app.post('/xml', xmlparser(), function (req, res) {
       res.json(req.body);
     });


### PR DESCRIPTION
I've been seeing exceptions thrown by this middleware and its taken a little while to figure it out!

The underlying issue is due to a [bug in xml2js](https://github.com/Leonidas-from-XIV/node-xml2js/pull/229) which means that running in async mode will actually run the parser twice. This was causing the middleware to crash when feeding invalid data such as `"<xml>hi</xml>`. 

Until this issue is fixed, setting `async` to `false` will solve this issue.

This underlying bug was also causing the issues noticed in #6. The first time the parser encounters an error, [all of its listeners are reset](https://github.com/Leonidas-from-XIV/node-xml2js/blob/master/lib/xml2js.js#L463), meaning that subsequent errors will not be handled and will bubble up to the top of the event pile. Node's default response here is to [throw an exception](https://github.com/joyent/node/blob/master/lib/events.js#L87), which is the behaviour we were seeing here.

Since this is no longer a problem, the custom saxParser's `onerror` callback is no longer needed, so I removed that too.

As soon as [this PR is merged](https://github.com/Leonidas-from-XIV/node-xml2js/pull/229), you should be able to set `async` back to `true`, if required.