### PR TITLE
Create parser on every request

### DIFF
--- a/lib/types/xml.js
+++ b/lib/types/xml.js
@@ -32,8 +32,6 @@ function xmlparser(options) {
       trim: true
     }, options || {});
 
-  var parser = new xml2js.Parser(parserOptions);
-
   /**
    * Provide connect/express-style middleware
    *
@@ -43,9 +41,12 @@ function xmlparser(options) {
    * @return {*}
    */
 
+
   function xmlbodyparser(req, res, next) {
 
     var data = '';
+
+    var parser = new xml2js.Parser(parserOptions);
 
     /**
      * @param {Error} err

--- a/test/test.js
+++ b/test/test.js
@@ -120,6 +120,14 @@ describe('XmlParserMiddleware', function () {
         .expect(400, done);
     });
 
+    it('should throw 400 on non-XML', function (done) {
+      request(app)
+        .post('/')
+        .set('Content-Type', 'application/xml')
+        .send('"johnny b. goode"')
+        .expect(400, done);
+    });
+
     it('should send 200 on empty xml root tag', function (done) {
       request(app)
         .post('/')


### PR DESCRIPTION
Here's another subtle one.

I was seeing an issue where the first time a non-XML request was received, an error was being thrown, but on subsequent requests, no error was apparent.

After pouring through the xml2js source I realised that the `parseString` instance method isn't reusable. You need to create a new parser each time you want to call `parseString`. The reason for this is that the parser [sets an instance variable when the underlying saxParser throws an error](https://github.com/Leonidas-from-XIV/node-xml2js/blob/master/src/xml2js.coffee#L236), and this needs to be reset in between invocations of `parseString`. The easiest way to achieve this is to just create a new parser per request, which is what the [convenience function in the xml2js module](https://github.com/Leonidas-from-XIV/node-xml2js/blob/master/src/xml2js.coffee#L420) also does.

I've added a new test case to reproduce this behaviour. 