### PR TITLE
fix: use module.exports.regexp in middleware

### DIFF
--- a/lib/types/xml.js
+++ b/lib/types/xml.js
@@ -70,7 +70,7 @@ function xmlparser(options) {
 
     req.body = req.body || {};
 
-    if (!hasBody(req) || !regexp.test(mime(req))) {
+    if (!hasBody(req) || !module.exports.regexp.test(mime(req))) {
       return next();
     }
 


### PR DESCRIPTION
I think you might have accidentally revert one of your fixes during refactoring. See https://github.com/macedigital/express-xml-bodyparser/commit/7472a316339fa946d51c0d65aa453919a4899ebc