### PR TITLE
replace util._extend with Object.assign

### DIFF
--- a/lib/types/xml.js
+++ b/lib/types/xml.js
@@ -7,7 +7,6 @@
 var xml2js = require('xml2js');
 var http = require('http');
 var regexp = /^(text\/xml|application\/([\w!#\$%&\*`\-\.\^~]+\+)?xml)$/i;
-var util = require('util');
 
 /**
  * Module exports.
@@ -26,7 +25,7 @@ module.exports.regexp = regexp;
 
 function xmlparser(options) {
 
-  var parserOptions = util._extend({
+  var parserOptions = Object.assign({
       async: false,
       explicitArray: true,
       normalize: true,


### PR DESCRIPTION
A simple change meant to remove the warning in newer versions of node.js